### PR TITLE
Update image cropping dependency

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,7 +16,7 @@ android {
         implementation "androidx.camera:camera-camera2:1.0.1"
         implementation "androidx.camera:camera-lifecycle:1.0.1"
         implementation "androidx.camera:camera-view:1.0.0-alpha27"
-        implementation 'com.theartofdev.edmodo:android-image-cropper:2.8.0'
+        implementation 'com.vanniktech:android-image-cropper:4.3.3'
         implementation 'com.google.android.exoplayer:exoplayer:2.18.2'
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,7 @@
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
         android:theme="@style/AppTheme">
-        <activity android:name="com.theartofdev.edmodo.cropper.CropImageActivity" />
+        <activity android:name="com.canhub.cropper.CropImageActivity" />
         <activity
             android:name=".CameraActivity"
             android:exported="true" />

--- a/app/src/main/res/layout/activity_camera.xml
+++ b/app/src/main/res/layout/activity_camera.xml
@@ -23,7 +23,7 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 
-    <com.theartofdev.edmodo.cropper.CropImageView
+    <com.canhub.cropper.CropImageView
         android:id="@+id/cropImageView"
         android:layout_width="match_parent"
         android:layout_height="match_parent"

--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,7 @@ allprojects {
     repositories {
         jcenter()
         google()
+        mavenCentral()
         maven { url "https://jitpack.io" }
     }
 }


### PR DESCRIPTION
# Migrate image cropper library

## Details

- Replaced `com.theartofdev.edmodo:android-image-cropper:2.8.0` with `com.vanniktech:android-image-cropper:4.3.3`
- Original library is no longer maintained or hosted on jitpack.io
- New library is an actively maintained fork available on Maven Central
- Updated implementation code to work with the new API

## Changes

Updated relevant code to handle significant API differences between the libraries.

* [`app/build.gradle`](diffhunk://#diff-51a0b488f963eb0be6c6599bf5df497313877cf5bdff3950807373912ac1cdc9L19-R19): Replaced the `com.theartofdev.edmodo:android-image-cropper` library with the `com.vanniktech:android-image-cropper` library.
* [`build.gradle`](diffhunk://#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7R18) Added Maven Central repo, as this is where `com.vanniktech:android-image-cropper` is hosted
* [`app/src/main/java/se/whitchurch/nordict/CameraActivity.kt`](diffhunk://#diff-bb67a04f04128bf06b94668dd4f97556a6d951f078fef543ad09ec5b123be6b1R7): Imported new classes from the `com.canhub.cropper` library and added a new `cropImage` activity result launcher. [[1]](diffhunk://#diff-bb67a04f04128bf06b94668dd4f97556a6d951f078fef543ad09ec5b123be6b1R7) [[2]](diffhunk://#diff-bb67a04f04128bf06b94668dd4f97556a6d951f078fef543ad09ec5b123be6b1L18-R49)
* [`app/src/main/java/se/whitchurch/nordict/CameraActivity.kt`](diffhunk://#diff-bb67a04f04128bf06b94668dd4f97556a6d951f078fef543ad09ec5b123be6b1L63-L86): Updated the image saving and cropping logic to use the new `CropImageContract` and `CropImageOptions`.
* [`app/src/main/java/se/whitchurch/nordict/CameraActivity.kt`](diffhunk://#diff-bb67a04f04128bf06b94668dd4f97556a6d951f078fef543ad09ec5b123be6b1R120-R136): Added error handling for camera use case binding and ensured permissions results are handled correctly.
* [`app/src/main/AndroidManifest.xml`](diffhunk://#diff-7fa6aef292187a049f7a4d6060d8df3ba212d838789c78940bd363344b1c38cdL21-R21): Updated the activity name for the image cropper to use the new library.
* [`app/src/main/res/layout/activity_camera.xml`](diffhunk://#diff-c4e47cce8b6803885777cce6b93cdefcff8f805a39fe1961d9c8c8c9941ef10eL26-R26): Replaced the old `CropImageView` with the new one from the `com.canhub.cropper` library.